### PR TITLE
Add NIST atomic weights

### DIFF
--- a/.github/workflows/atomic_weights.yml
+++ b/.github/workflows/atomic_weights.yml
@@ -1,0 +1,76 @@
+name: Check NIST atomic weights
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'  #runs on every Sunday midnight
+  workflow_dispatch:
+  
+env:
+  ATOMIC_WEIGHTS_URL: 'http://physics.nist.gov/cgi-bin/Compositions/stand_alone.pl'        #URL of the NIST atomic weights
+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+
+    steps:
+      - uses: act10ns/slack@v2.0.0
+        with:
+          status: starting
+          message: Starting check NIST atomic weights
+        if: always()
+        
+      - name: Checkout github repo
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+
+      - name: Configure git
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
+          
+      - name: Set up Python
+        id: set_python
+        uses: actions/setup-python@v3
+        
+      - name: Install dependencies
+        id: install_dependencies
+        run: | 
+          pip install -r requirements.txt
+          pip install html5lib 
+        
+      - name: Run Python script
+        id: run_script
+        run: | 
+          python atomic_weights.py
+          
+      - name: Compare changes
+        id: compare
+        continue-on-error: true
+        run: |
+          git add .
+          git diff --quiet --exit-code --cached
+
+      - name: Commit files to git
+        id: commit_changes
+        if: ${{ steps.compare.outcome == 'failure' }}
+        run: |
+          git commit -m "nist atomic weights added"
+
+      - name: Push changes
+        if: ${{ steps.compare.outcome == 'failure' }}
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}
+          
+      - name: Report status 
+        uses: act10ns/slack@v2.0.0
+        with:
+          status: ${{ job.status }}
+          steps: ${{ toJson(steps) }}
+        if: always()
+          

--- a/atomic_weights.py
+++ b/atomic_weights.py
@@ -35,6 +35,21 @@ def download_weightscomp(ascii='ascii2', isotype='some'):
 
 # Check and create a path to save files
 def check_folders(folder_name, file_name):
+    """
+    Check if the folder exists, and create it if it doesn't.
+
+    Parameters
+    ----------
+    folder_name : str
+        The folder name to check or create.
+    file_name : str
+        The name of the file.
+
+    Returns
+    -------
+    str
+        The full file path.
+    """
     if not os.path.exists(folder_name):  # to check if the folder exists, and create it if not
         os.makedirs(folder_name)
 
@@ -43,6 +58,18 @@ def check_folders(folder_name, file_name):
     
 # Format the data
 def parse_html_content(html_content):
+    """
+    Parses the HTML content and saves the data as CSV.
+
+    Parameters
+    ----------
+    html_content : str
+        The preformatted HTML content.
+
+    Returns
+    -------
+    None
+    """
     html_file_path = check_folders('html_files', 'weights.html')
     with open(html_file_path, "w", encoding="utf-8") as file:   # Save the html data to a file
         file.write(html_content)
@@ -67,4 +94,5 @@ def parse_html_content(html_content):
     df.to_csv(csv_file_path, index=False)
     return
         
-atomic_weights = parse_html_content(download_weightscomp())
+if __name__ == "__main__":
+    atomic_weights = parse_html_content(download_weightscomp())

--- a/atomic_weights.py
+++ b/atomic_weights.py
@@ -1,0 +1,60 @@
+import requests
+import pandas as pd
+from bs4 import BeautifulSoup
+
+# Download data
+WEIGHTSCOMP_URL = "http://physics.nist.gov/cgi-bin/Compositions/stand_alone.pl"
+
+def download_weightscomp(ascii='ascii2', isotype='some'):
+    """
+    Downloader function for the NIST Atomic Weights and Isotopic Compositions database
+
+    Makes a GET request to download data; then extracts preformatted text
+
+    Parameters
+    ----------
+    ascii: str
+        GET request parameter, refer to the NIST docs
+        (default: 'ascii')
+    isotype: str
+        GET request parameter, refer to the NIST docs
+        (default: 'some')
+
+    Returns
+    -------
+    str
+        Preformatted text data
+
+    """
+    r = requests.get(url=WEIGHTSCOMP_URL, params={'ascii': ascii, 'isotype': isotype})
+    soup = BeautifulSoup(r.text, 'html5lib')
+    pre_text_data = soup.pre.get_text()
+    pre_text_data = pre_text_data.replace(u'\xa0', u' ')  # replace non-breaking spaces with spaces
+    return pre_text_data
+
+# Format the data
+def parse_html_content(html_content):
+    data = []
+    lines = html_content.strip().split('\n')
+    entry = {}
+    
+    for line in lines:
+        if '=' in line:
+            key, value = line.split('=', 1)
+            entry[key.strip()] = value.strip()
+        else:
+            data.append(entry)
+            entry = {}
+    
+    data.append(entry)  # Append the last entry
+    
+    return data
+
+data = parse_html_content(download_weightscomp())
+df = pd.DataFrame(data)
+df = df.iloc[2:]
+
+# Save the DataFrame to CSV file
+df.to_csv('nist_atomic_weights.csv', index=False)
+
+print("Data extracted and saved to 'nist_atomic_weights.csv'.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+requests>=2.0.0
+beautifulsoup4>=4.0.0
+html5lib>=1.0.0
+pandas>=1.0.0 


### PR DESCRIPTION
### :pencil: Workflow to download the NIST atomic weights and isotopic compositions

**Type:**  :rocket: `feature` 



This workflow will run every Sunday at midnight and download the atomic weights and isotopic composition of all the elements available in the NIST Atomic Spectra Database. The data will be saved in a `CSV` file.


### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [x] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
