### PR TITLE
Add NIST information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 # carsus-data-nist
+`carsus-data-nist` mirrors the atomic weights, isotopic compositions and ionization energies available at the National Institute of Standards and Technology, Atomic Spectra Database (NIST ASD).
+
+Note: If anyone uses this data, please cite the references mentioned in the original database. To learn more about the NIST ASD, please refer to https://www.nist.gov/pml/atomic-spectra-database.


### PR DESCRIPTION
### :pencil: Information about the source of the atomic weights and ionization energies available on the `carsus-data-nist` repository

**Type:**  :memo: `documentation` 

This PR updates the `README.md` file by adding a disclaimer about the atomic data saved on the `carsus-data-nist` repository.

Also, link issues affected by this pull request by using the keywords: `close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves` or `resolved`. 


### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [x] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
