### PR TITLE
Add nist_url argument in download_ionization_energies and download_weights

### DIFF
--- a/atomic_weights.py
+++ b/atomic_weights.py
@@ -44,4 +44,4 @@ def parse_weights_html_content(html_content):
     return
 
 if __name__ == "__main__":
-    atomic_weights = parse_weights_html_content(download_weightscomp())
+    atomic_weights = parse_weights_html_content(download_weightscomp(nist_url=True))

--- a/ionization.py
+++ b/ionization.py
@@ -41,4 +41,4 @@ def parse_ionization_html_content(html_data):
     return
 
 if __name__ == "__main__":
-        ionization_energies = parse_ionization_html_content(download_ionization_energies())
+        ionization_energies = parse_ionization_html_content(download_ionization_energies(nist_url=True))


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` 

This PR will add the `nist_url=true` argument in the download_ionization_energies and download_weights function that will ensure the data in the `carsus-data-nist` repo is downloaded from NIST URL.




### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
